### PR TITLE
Fix open day date to 27 March 2026

### DIFF
--- a/content/home/banner.md
+++ b/content/home/banner.md
@@ -20,4 +20,4 @@ design:
     text_color_light: true
 hero_media: KSI_logo_color_h_pl_med.png
 ---
-Zapraszamy na dzień otwarty Kierunku Sztuczna Inteligencja - 23 marca 2026. [Szczegóły](https://wit.pwr.edu.pl/aktualnosci/dzien-otwarty/edycja-2026/program-2.html)
+Zapraszamy na dzień otwarty Kierunku Sztuczna Inteligencja - 27 marca 2026. [Szczegóły](https://wit.pwr.edu.pl/aktualnosci/dzien-otwarty/edycja-2026/program-2.html)


### PR DESCRIPTION
## Summary
- Update open day date from 23 marca to 27 marca 2026 in the banner

## Test plan
- [ ] Verify banner displays correct date on the homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)